### PR TITLE
fix ssl時にrewriteが有効になっていなかった

### DIFF
--- a/aws-mt/roles/httpd/templates/conf.d/ssl.conf
+++ b/aws-mt/roles/httpd/templates/conf.d/ssl.conf
@@ -10,6 +10,9 @@ SSLCryptoDevice builtin
   DocumentRoot /var/www/{{ server_name }}
   ServerName {{ server_name }}
 
+  RewriteEngine On
+  RewriteOptions Inherit
+
   ErrorLog logs/ssl_{{ server_name }}-error_log
 
   LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" 

--- a/aws-mt/roles/httpd/templates/conf.d/ssl.conf
+++ b/aws-mt/roles/httpd/templates/conf.d/ssl.conf
@@ -10,8 +10,10 @@ SSLCryptoDevice builtin
   DocumentRoot /var/www/{{ server_name }}
   ServerName {{ server_name }}
 
-  RewriteEngine On
-  RewriteOptions Inherit
+  <IfModule mod_rewrite.c>
+    RewriteEngine On
+    RewriteOptions Inherit
+  </IfModule>
 
   ErrorLog logs/ssl_{{ server_name }}-error_log
 


### PR DESCRIPTION
http接続時はhtaccessのRewrite機能が有効になっていて、https時は効いていなかったので直しました。
Apache2.4のときに起きるような感じです。